### PR TITLE
Add network ID to config

### DIFF
--- a/decawave_ble/__init__.py
+++ b/decawave_ble/__init__.py
@@ -926,6 +926,10 @@ def write_data_multiple_devices_to_text_local(data_multiple, path):
             file.write('Device type: {}\n'.format(decawave_device['operation_mode_data']['device_type_name']))
             file.write('Initiator: {}\n'.format(decawave_device['operation_mode_data']['initiator']))
             file.write('UWB mode: {}\n'.format(decawave_device['operation_mode_data']['uwb_mode_name']))
+            if decawave_device['network_id'] is not None:
+                file.write('Network ID: {:02X}\n'.format(decawave_device['network_id']))
+            else:
+                file.write('Network ID: None\n')
             if decawave_device['update_rate_data'] is not None:
                 file.write('Moving update rate (ms): {}\n'.format(decawave_device['update_rate_data']['moving_update_rate']))
                 file.write('Stationary update rate (ms): {}\n'.format(decawave_device['update_rate_data']['stationary_update_rate']))

--- a/decawave_ble/__init__.py
+++ b/decawave_ble/__init__.py
@@ -539,6 +539,68 @@ def parse_network_id_bytes(network_id_bytes):
     else:
         return None
 
+# Functions for writing network ID
+
+def set_network_id(
+    decawave_device,
+    network_id = None,
+    check_config_enabled = False):
+    decawave_peripheral = get_decawave_peripheral(decawave_device)
+    set_network_id_to_peripheral(
+        decawave_peripheral,
+        network_id,
+        check_config_enabled)
+    decawave_peripheral.disconnect()
+
+@exponential_retry
+def set_operation_mode_to_peripheral(
+    decawave_peripheral,
+    network_id = None,
+    check_config_enabled = False):
+    if network_id is not None:
+        write_network_id_to_peripheral(
+            decawave_peripheral,
+            network_id)
+    if check_config_enabled:
+        check_network_id_from_peripheral(
+            decawave_peripheral,
+            network_id)
+
+def check_network_id_from_peripheral(
+    decawave_peripheral,
+    network_id = None):
+    current_network_id = get_network_id_from_peripheral(decawave_peripheral)
+    if network_id is not None:
+        if current_network_id != network_id:
+            raise ValueError('Network ID was set to {} but returned {}'.format(
+                network_id,
+                current_network_id))
+
+def write_network_id(
+    decawave_device,
+    network_id):
+    decawave_peripheral = get_decawave_peripheral(decawave_device)
+    write_network_id_to_peripheral(
+        decawave_peripheral,
+        network_id)
+    decawave_peripheral.disconnect()
+
+@exponential_retry
+def write_network_id_to_peripheral(
+    decawave_peripheral,
+    network_id):
+    bytes = pack_network_id_bytes(network_id)
+    write_decawave_characteristic_to_peripheral(
+        decawave_peripheral,
+        NETWORK_ID_CHARACTERISTIC_UUID,
+        bytes)
+
+def pack_network_id_bytes(network_id):
+    network_id_bytes = bitstruct.pack(
+        'u16<',
+        network_id)
+    return network_id_bytes
+
 # Functions for getting proxy positions data
 def get_proxy_positions_data(decawave_device):
     decawave_peripheral = get_decawave_peripheral(decawave_device)

--- a/decawave_ble/__init__.py
+++ b/decawave_ble/__init__.py
@@ -922,12 +922,12 @@ def write_data_multiple_devices_to_text_local(data_multiple, path):
         file.write('Data for {} Decawave devices\n'.format(len(data_multiple)))
         for device_name, decawave_device in data_multiple.items():
             file.write('\nDevice name: {}\n'.format(device_name))
-            file.write('Node ID: {:#016X}\n'.format(decawave_device['device_info_data']['node_id']))
+            file.write('Node ID: {:016X}\n'.format(decawave_device['device_info_data']['node_id']))
             file.write('Device type: {}\n'.format(decawave_device['operation_mode_data']['device_type_name']))
             file.write('Initiator: {}\n'.format(decawave_device['operation_mode_data']['initiator']))
             file.write('UWB mode: {}\n'.format(decawave_device['operation_mode_data']['uwb_mode_name']))
             if decawave_device['network_id'] is not None:
-                file.write('Network ID: {:#04X}\n'.format(decawave_device['network_id']))
+                file.write('Network ID: {:04X}\n'.format(decawave_device['network_id']))
             else:
                 file.write('Network ID: None\n')
             if decawave_device['update_rate_data'] is not None:

--- a/decawave_ble/__init__.py
+++ b/decawave_ble/__init__.py
@@ -194,6 +194,7 @@ def set_config(
     initiator = None,
     low_power_mode = None,
     location_engine = None,
+    network_id = None,
     moving_update_rate = None,
     stationary_update_rate = None,
     x_position = None,
@@ -211,6 +212,10 @@ def set_config(
         initiator,
         low_power_mode,
         location_engine,
+        check_config_enabled)
+    set_network_id_to_peripheral(
+        decawave_peripheral,
+        network_id,
         check_config_enabled)
     set_update_rate_to_peripheral(
         decawave_peripheral,
@@ -233,6 +238,9 @@ def write_data(
     write_operation_mode_data_to_peripheral(
         decawave_peripheral,
         data['operation_mode_data'])
+    write_network_id_to_peripheral(
+        decawave_peripheral,
+        data['network_id'])
     write_update_rate_data_to_peripheral(
         decawave_peripheral,
         data['update_rate_data'])
@@ -553,7 +561,7 @@ def set_network_id(
     decawave_peripheral.disconnect()
 
 @exponential_retry
-def set_operation_mode_to_peripheral(
+def set_network_id_to_peripheral(
     decawave_peripheral,
     network_id = None,
     check_config_enabled = False):

--- a/decawave_ble/__init__.py
+++ b/decawave_ble/__init__.py
@@ -922,12 +922,12 @@ def write_data_multiple_devices_to_text_local(data_multiple, path):
         file.write('Data for {} Decawave devices\n'.format(len(data_multiple)))
         for device_name, decawave_device in data_multiple.items():
             file.write('\nDevice name: {}\n'.format(device_name))
-            file.write('Node ID: {:08X}\n'.format(decawave_device['device_info_data']['node_id']))
+            file.write('Node ID: {:#016X}\n'.format(decawave_device['device_info_data']['node_id']))
             file.write('Device type: {}\n'.format(decawave_device['operation_mode_data']['device_type_name']))
             file.write('Initiator: {}\n'.format(decawave_device['operation_mode_data']['initiator']))
             file.write('UWB mode: {}\n'.format(decawave_device['operation_mode_data']['uwb_mode_name']))
             if decawave_device['network_id'] is not None:
-                file.write('Network ID: {:02X}\n'.format(decawave_device['network_id']))
+                file.write('Network ID: {:#04X}\n'.format(decawave_device['network_id']))
             else:
                 file.write('Network ID: None\n')
             if decawave_device['update_rate_data'] is not None:

--- a/decawave_ble/configure_devices.py
+++ b/decawave_ble/configure_devices.py
@@ -36,6 +36,7 @@ def configure_devices_from_database(configuration_database):
             initiator=target_data.get('initiator'),
             low_power_mode=target_data.get('low_power_mode'),
             location_engine=target_data.get('location_engine'),
+            network_id=target_data.get('network_id'),
             moving_update_rate=target_data.get('moving_update_rate'),
             stationary_update_rate=target_data.get('stationary_update_rate'),
             x_position=target_data.get('x_position'),

--- a/decawave_ble/configure_devices.py
+++ b/decawave_ble/configure_devices.py
@@ -26,6 +26,13 @@ def configure_devices_from_database(configuration_database):
         logger.info('Getting target data for {}'.format(target_device_name))
         target_data = configuration_database.get_target_data(target_device_name)
         logger.info('Target data: {}'.format(target_data))
+        network_id = None
+        if target_data.get('network_id_hex_string') is not None:
+            if target_data.get('network_id_integer') is not None:
+                raise ValueError('You can specify network_id_hex_string or network_id_integer but not both')
+            network_id = int(target_data.get('network_id_hex_string'), 16)
+        if target_data.get('network_id_integer') is not None:
+            network_id = target_data.get('network_id_integer')
         logger.info('Writing target data')
         decawave_ble.set_config(
             devices[target_device_name],
@@ -36,7 +43,7 @@ def configure_devices_from_database(configuration_database):
             initiator=target_data.get('initiator'),
             low_power_mode=target_data.get('low_power_mode'),
             location_engine=target_data.get('location_engine'),
-            network_id=target_data.get('network_id'),
+            network_id=network_id,
             moving_update_rate=target_data.get('moving_update_rate'),
             stationary_update_rate=target_data.get('stationary_update_rate'),
             x_position=target_data.get('x_position'),

--- a/decawave_ble/configure_devices.py
+++ b/decawave_ble/configure_devices.py
@@ -26,13 +26,14 @@ def configure_devices_from_database(configuration_database):
         logger.info('Getting target data for {}'.format(target_device_name))
         target_data = configuration_database.get_target_data(target_device_name)
         logger.info('Target data: {}'.format(target_data))
-        network_id = None
-        if target_data.get('network_id_hex_string') is not None:
-            if target_data.get('network_id_integer') is not None:
-                raise ValueError('You can specify network_id_hex_string or network_id_integer but not both')
-            network_id = int(target_data.get('network_id_hex_string'), 16)
-        if target_data.get('network_id_integer') is not None:
-            network_id = target_data.get('network_id_integer')
+        if target_data.get('network_id') is not None:
+            try:
+                network_id = int(target_data.get('network_id'))
+            except:
+                try:
+                    network_id = int(target_data.get('network_id'), base=0)
+                except:
+                    raise ValueError('Network ID {} is not of a recognized type'.format(network_id))
         logger.info('Writing target data')
         decawave_ble.set_config(
             devices[target_device_name],


### PR DESCRIPTION
User can now specify network ID in config database as `network_id_hex_string` or `network_id_integer`. I like the idea of giving the user options (and being permissive in inputs and strict in outputs), but the way I implemented this feels like a bit of a hack. Ideally, the script would just inspect the data and decide whether it was a hex string or a decimal integer, but the problem is that inputs like `100` are genuinely ambiguous. Would love feedback on this.

I also haven't implemented some of the other changes we talked about (e.g., making a certain subset of config variables mandatory, combining `decawave_ble` with `decawave_serial`). I'll save those for future merges,